### PR TITLE
Feature/convert to timezone for hubs

### DIFF
--- a/src/Service.php
+++ b/src/Service.php
@@ -30,6 +30,11 @@ class Service extends \Buzz\EssentialsSdk\Service
     protected static $stream;
 
     /**
+     * @var bool
+     */
+    protected static $force_campaign_timezone = false;
+
+    /**
      * @var string
      */
     protected static $custom_header_prefix = 'BUZZ-';
@@ -77,12 +82,29 @@ class Service extends \Buzz\EssentialsSdk\Service
     }
 
     /**
+     * Sets headers for forcing timezone which forces
+     * all date-times to return in the campaign
+     * timezone so no more messing around with
+     * configuring date and times
+     *
+     * @return void
+     */
+    public static function forceCampaignTimezones(bool $toggle)
+    {
+        self::$force_campaign_timezone = $toggle;
+    }
+
+    /**
      *
      */
     protected function prepareHeaders()
     {
         if (self::$stream) {
             $this->setCustomHeader('Stream', self::$stream);
+        }
+
+        if (self::$force_campaign_timezone) {
+            $this->setCustomHeader('force-campaign-timezone', true);
         }
 
         parent::prepareHeaders();


### PR DESCRIPTION
To test this feature you will need to use pull feature/convert-to-timezone-for-hubs on the following branches :
control
v3-reg-kickstart
v3-exhibitor-hub

The timezone features do not work in the hubs unless the API toggle is on in LC which is dangerous as some orgs use the API heavily and will rely on date/times being in UTC. This feature allows you to force LC to return the date/times in the campaign timezone regardless of the settings in LC.

Since almost all hubs will handle conversions this feature will migitgate having to do any conversions full stop. In both v3-reg-kickstart and v3-exhibitor-hub make sure you both are using your locally pulled control-sdk, then edit the buzz config file and toggle force_campaign_timezone to true. Since LC defaults to Europe/London it will return all times in that timezone unless Display dates times in timezone is set in LC settings.